### PR TITLE
Use forward slash for ZIP file paths

### DIFF
--- a/pack/manifest.go
+++ b/pack/manifest.go
@@ -46,9 +46,18 @@ func GetFiles(manifest Manifest) (filesList []string) {
 	for _, file := range filesList {
 		log.Println(file)
 	}
-	filesList = removeDuplicateFiles(filesList)
+	filesList = normalizeSlashes(removeDuplicateFiles(filesList))
 	return
 }
+
+func normalizeSlashes(filesList []string) []string {
+	filesListNormalized := []string{}
+	for _, file := range filesList {
+		filesListNormalized = append(filesListNormalized, filepath.ToSlash(file))
+	}
+	return filesListNormalized
+}
+
 
 func removeDuplicateFiles(filesList []string) []string {
 	log.Println("Removing duplicated files")


### PR DESCRIPTION
Using backslashes in ZIP file paths causes problems
when extracting on Linux servers